### PR TITLE
Add `/request` Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Simple `echoserver`, which dumps HTTP requests.
 - `/status`: Returns a random status code, when the `status` parameter is empty or `random`. Return the status code specified in the `status` parameter, e.g. `?status=200`.
 - `/timeout`: Wait the given amount of time (`?timeout=1m`) before returning a 200 status code.
 - `/headersize`: Returns a 200 status code with a header `X-Header-Size` of the size defined via `?size=1024`.
+- `/request`: Returns the response of the requested server. The request body should have the following structure: `{"method": "POST", "url": "http://localhost:8080/", "body": "test", "headers": {"x-test": "test"}}`
 - `/metrics`: Returns the captured Prometheus metrics.
 
 ## Build
@@ -46,4 +47,5 @@ curl -vvv "http://localhost:8080/status"
 curl -vvv "http://localhost:8080/status?status=400"
 curl -vvv "http://localhost:8080/timeout?timeout=10s"
 curl -vvv "http://localhost:8080/headersize?size=100"
+curl -vvv -X POST -d '{"method": "POST", "url": "http://localhost:8080/", "body": "test", "headers": {"x-test": "test"}}' http://localhost:8080/request
 ```

--- a/cmd/echoserver/echoserver.go
+++ b/cmd/echoserver/echoserver.go
@@ -59,6 +59,7 @@ func (c *Cli) run() error {
 	router.HandleFunc("/status", statusHandler)
 	router.HandleFunc("/timeout", timeoutHandler)
 	router.HandleFunc("/headersize", headerSizeHandler)
+	router.HandleFunc("/request", requestHandler)
 	router.Handle("/metrics", promhttp.Handler())
 
 	server := &http.Server{

--- a/cmd/echoserver/handlers.go
+++ b/cmd/echoserver/handlers.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/big"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-chi/render"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 )
@@ -151,4 +157,74 @@ func headerSizeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Header-Size", strings.Repeat("0", size))
 	render.Status(r, http.StatusOK)
 	render.Data(w, r, []byte(http.StatusText(http.StatusOK)))
+}
+
+var httpClient = &http.Client{
+	Transport: otelhttp.NewTransport(
+		http.DefaultTransport,
+		otelhttp.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
+			return otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans())
+		}),
+	),
+}
+
+type Request struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Body    string            `json:"body"`
+	Headers map[string]string `json:"headers"`
+}
+
+func requestHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, span := handlerTracer.Start(r.Context(), "requestHandler")
+	defer span.End()
+
+	var request Request
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		slog.ErrorContext(ctx, "Failed to decode request body.", slog.Any("error", err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, request.Method, request.URL, strings.NewReader(request.Body))
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create http request.", slog.Any("error", err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	for key, value := range request.Headers {
+		req.Header.Add(key, value)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to do http request.", slog.Any("error", err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to read reespons body.", slog.Any("error", err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	render.Status(r, resp.StatusCode)
+	render.Data(w, r, body)
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/go-chi/render v1.0.3
 	github.com/prometheus/client_golang v1.21.1
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.60.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.60.0 h1:0tY123n7CdWMem7MOVdKOt0YfshufLCwfE5Bob+hQuM=
+go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.60.0/go.mod h1:CosX/aS4eHnG9D7nESYpV753l4j9q5j3SL/PUYd2lR8=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
 go.opentelemetry.io/contrib/propagators/b3 v1.35.0 h1:DpwKW04LkdFRFCIgM3sqwTJA/QREHMeMHYPWP1WeaPQ=
 go.opentelemetry.io/contrib/propagators/b3 v1.35.0/go.mod h1:9+SNxwqvCWo1qQwUpACBY5YKNVxFJn5mlbXg/4+uKBg=
 go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
@@ -73,8 +77,8 @@ go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/
 go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
 go.opentelemetry.io/otel/sdk v1.35.0 h1:iPctf8iprVySXSKJffSS79eOjl9pvxV9ZqOWT0QejKY=
 go.opentelemetry.io/otel/sdk v1.35.0/go.mod h1:+ga1bZliga3DxJ3CQGg3updiaAJoNECOgJREo9KHGQg=
-go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce1EK0Gyvahk=
-go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
+go.opentelemetry.io/otel/sdk/metric v1.35.0 h1:1RriWBmCKgkeHEhM7a2uMjMUfP7MsOF5JpUCaEqEI9o=
+go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=


### PR DESCRIPTION
The new `/request` handler can be used to get the request of another
server. For that a post request can be sent against the `/request`
endpoint with a bodz which contains the method, url, body and headers of
the request which should be executed against the target server, e.g.

```
curl -vvv -X POST -d '{"method": "POST", "url": "http://localhost:8080/", "body": "test", "headers": {"x-test": "test"}}' http://localhost:8080/request
```
