### PR TITLE
Test Docker Build in Continuous Integration GitHub Action

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,7 +2,10 @@
 name: Continuous Integration
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   go:
@@ -35,3 +38,27 @@ jobs:
       - name: Build
         run: |
           make build
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          context: .
+          file: ./cmd/echoserver/Dockerfile
+          platforms: linux/amd64


### PR DESCRIPTION
- Test the Docker Build in the Continuous Integration GitHub Action
- Add `pull_request` as trigger for GitHub Action
- Use `push` trigger for GitHub Action only on the `main` branch