### PR TITLE
Add Profiling Endpoints

### DIFF
--- a/cmd/echoserver/echoserver.go
+++ b/cmd/echoserver/echoserver.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -61,6 +62,17 @@ func (c *Cli) run() error {
 	router.HandleFunc("/headersize", headerSizeHandler)
 	router.HandleFunc("/request", requestHandler)
 	router.Handle("/metrics", promhttp.Handler())
+	router.HandleFunc("/debug/pprof", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	router.Handle("/debug/pprof/block", pprof.Handler("block"))
+	router.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	router.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	router.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	router.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	router.Handle("/debug/pprof/trace", pprof.Handler("trace"))
 
 	server := &http.Server{
 		Addr:              c.Address,


### PR DESCRIPTION
Add `/debug/pprof` endpoints from the `net/http/pprof` package.
