### PR TITLE
Add `/fibonacci` Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Simple `echoserver`, which dumps HTTP requests.
 - `/request`: Returns the response of the requested server. The request body
   should have the following structure:
   `{"method": "POST", "url": "http://localhost:8080/", "body": "test", "headers": {"x-test": "test"}}`
+- `/fibonacci`: Returns the Fibonacci number for the given `n` parameter, e.g.
+  `?n=100`. The intention behind this endpoint is to simulate a CPU-intensive
+  task.
 - `/metrics`: Returns the captured Prometheus metrics.
 
 ## Building and Running
@@ -50,4 +53,5 @@ curl -vvv "http://localhost:8080/status?status=400"
 curl -vvv "http://localhost:8080/timeout?timeout=10s"
 curl -vvv "http://localhost:8080/headersize?size=100"
 curl -vvv -X POST -d '{"method": "POST", "url": "http://localhost:8080/", "body": "test", "headers": {"x-test": "test"}}' http://localhost:8080/request
+curl -vvv "http://localhost:8080/fibonacci?n=100"
 ```

--- a/cmd/echoserver/echoserver.go
+++ b/cmd/echoserver/echoserver.go
@@ -62,6 +62,7 @@ func (c *Cli) run() error {
 	router.HandleFunc("/timeout", timeoutHandler)
 	router.HandleFunc("/headersize", headerSizeHandler)
 	router.HandleFunc("/request", requestHandler)
+	router.HandleFunc("/fibonacci", fibonacciHandler)
 	router.Handle("/metrics", promhttp.Handler())
 	router.HandleFunc("/debug/pprof", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/cmd/echoserver/handlers_test.go
+++ b/cmd/echoserver/handlers_test.go
@@ -203,3 +203,42 @@ func TestRequest(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
+
+func TestFibonacciHandler(t *testing.T) {
+	t.Run("should return fibonacci number", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?n=10", nil)
+		w := httptest.NewRecorder()
+
+		router := chi.NewRouter()
+		router.HandleFunc("/", fibonacciHandler)
+		router.ServeHTTP(w, req)
+
+		body, err := io.ReadAll(w.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "55", string(body))
+	})
+
+	t.Run("should return error if parameter 'n' is missing", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		router := chi.NewRouter()
+		router.HandleFunc("/", fibonacciHandler)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("should return error if parameter 'n' is not a number", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?n=invalid", nil)
+		w := httptest.NewRecorder()
+
+		router := chi.NewRouter()
+		router.HandleFunc("/", fibonacciHandler)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}


### PR DESCRIPTION
The new `/fibonacci` endpoint can be use to calculate the fibonacci
number of the given parameter `n`, e.g.

```
curl -vvv "http://localhost:8080/fibonacci?n=100"
```

The intention behind this endpoint is to simulate a CPU-intensive task,
to showcase the profiling endpoints.
