### PR TITLE
Add `/websocket` Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ proxy. The following endpoints are available:
 - `/fibonacci`: Returns the Fibonacci number for the given `n` parameter, e.g.
   `?n=100`. The intention behind this endpoint is to simulate a CPU-intensive
   task.
+- `/websocket`: Can be used to test WebSocket connections. It returns the
+  message sent over the WebSocket connection.
 - `/metrics`: Returns the captured Prometheus metrics.
 
 ## Building and Running

--- a/cmd/echoserver/echoserver.go
+++ b/cmd/echoserver/echoserver.go
@@ -63,6 +63,7 @@ func (c *Cli) run() error {
 	router.HandleFunc("/headersize", headerSizeHandler)
 	router.HandleFunc("/request", requestHandler)
 	router.HandleFunc("/fibonacci", fibonacciHandler)
+	router.HandleFunc("/websocket", websocketHandler)
 	router.Handle("/metrics", promhttp.Handler())
 	router.HandleFunc("/debug/pprof", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/render v1.0.3
+	github.com/gorilla/websocket v1.5.3
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.61.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7 h1:y3N7Bm7Y9/CtpiVkw/
 github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=


### PR DESCRIPTION
Add a new `/websocket` endpoint, which can be used to test WebSocket
connections. The endpoint just returns the message sent by the client.
