### PR TITLE
Fix Tracer Name

### DIFF
--- a/cmd/echoserver/handlers.go
+++ b/cmd/echoserver/handlers.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-var handlerTracer = otel.Tracer("techdocs")
+var handlerTracer = otel.Tracer("handler")
 
 func echoHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, span := handlerTracer.Start(r.Context(), "echoHandler")


### PR DESCRIPTION
The name of the tracer used for the HTTP handlers was wrong. It was
`techdocs` because I copied it from one of my other prjects and forgot
to change it. Now the name is `handler` which makes more sense.
