### PR TITLE
feat(prometheus): add option to include resource attributes in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ export LOG_FORMAT="console"
 export LOG_LEVEL="INFO"
 export LOG_RESOURCE_ATTRIBUTES="true"
 
+# When "OTEL_METRICS_EXPORTER" is set to "prometheus", the following environment
+# variables can be used to configure the Prometheus metrics:
+export PROMETHEUS_RESOURCE_ATTRIBUTES="service.name,service.namespace"
+
 # When "OTEL_PROFILES_EXPORTER" is set to "pyroscope", the following environment
 # variables are required:
 # - PYROSCOPE_SERVER_ADDRESS: The address of the Pyroscope server.

--- a/pkg/instrument/client.go
+++ b/pkg/instrument/client.go
@@ -208,8 +208,16 @@ func newMeterProvider(ctx context.Context, defaultResource *resource.Resource) (
 			metric.WithResource(defaultResource),
 		), nil
 	case "prometheus":
+		var resourceAttributes []attribute.Key
+		for value := range strings.SplitSeq(os.Getenv("PROMETHEUS_RESOURCE_ATTRIBUTES"), ",") {
+			resourceAttributes = append(resourceAttributes, attribute.Key(value))
+		}
+
 		exp, err := promexp.New(
 			promexp.WithoutScopeInfo(),
+			promexp.WithResourceAsConstantLabels(attribute.NewAllowKeysFilter(
+				resourceAttributes...,
+			)),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The new `PROMETHEUS_RESOURCE_ATTRIBUTES` environment variable allows
users to include OTEL resources attributes in the Prometheus metrics as
labels.
