### PR TITLE
test: cover gRPC server and HTTP server handlers

### DIFF
--- a/pkg/grpcserver/echoserver_test.go
+++ b/pkg/grpcserver/echoserver_test.go
@@ -1,0 +1,141 @@
+package grpcserver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	pb "github.com/ricoberger/echoserver/pkg/grpcserver/proto"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/reflection"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+func TestEcho(t *testing.T) {
+	t.Run("should echo the message", func(t *testing.T) {
+		e := NewEchoserver()
+
+		resp, err := e.Echo(context.Background(), &pb.EchoRequest{Message: "hello"})
+		require.NoError(t, err)
+		require.Equal(t, "hello", resp.GetMessage())
+	})
+}
+
+func TestStatus(t *testing.T) {
+	e := NewEchoserver()
+
+	t.Run("should return no error for the OK status", func(t *testing.T) {
+		_, err := e.Status(context.Background(), &pb.StatusRequest{Status: "OK"})
+		require.NoError(t, err)
+	})
+
+	t.Run("should return the matching status code", func(t *testing.T) {
+		_, err := e.Status(context.Background(), &pb.StatusRequest{Status: "NOT_FOUND"})
+		require.Equal(t, grpccodes.NotFound, grpcstatus.Code(err))
+	})
+
+	t.Run("should return an internal error for an unknown status", func(t *testing.T) {
+		_, err := e.Status(context.Background(), &pb.StatusRequest{Status: "DOES_NOT_EXIST"})
+		require.Equal(t, grpccodes.Internal, grpcstatus.Code(err))
+	})
+
+	t.Run("should handle a random status", func(t *testing.T) {
+		// A random status may resolve to OK (no error) or to an error status,
+		// so we only ensure the call does not panic and returns a response.
+		resp, _ := e.Status(context.Background(), &pb.StatusRequest{Status: "random"})
+		require.NotNil(t, resp)
+	})
+}
+
+func TestSimulate(t *testing.T) {
+	e := NewEchoserver()
+
+	t.Run("should simulate each type", func(t *testing.T) {
+		requests := []*pb.SimulateRequest{
+			{Type: "cpu", Duration: "10ms"},
+			{Type: "memory", Duration: "10ms", Size: 1024},
+			{Type: "goroutines", Duration: "10ms", Count: 4},
+			{Type: "mutex", Duration: "10ms", Workers: 4},
+			{Type: "block", Duration: "10ms", Workers: 4},
+		}
+
+		for _, request := range requests {
+			resp, err := e.Simulate(context.Background(), request)
+			require.NoError(t, err)
+			require.Contains(t, resp.GetMessage(), request.GetType())
+		}
+	})
+
+	t.Run("should return an error when the type is missing", func(t *testing.T) {
+		_, err := e.Simulate(context.Background(), &pb.SimulateRequest{Duration: "10ms"})
+		require.Equal(t, grpccodes.InvalidArgument, grpcstatus.Code(err))
+	})
+
+	t.Run("should return an error when the duration is missing", func(t *testing.T) {
+		_, err := e.Simulate(context.Background(), &pb.SimulateRequest{Type: "cpu"})
+		require.Equal(t, grpccodes.InvalidArgument, grpcstatus.Code(err))
+	})
+
+	t.Run("should return an error when the duration is invalid", func(t *testing.T) {
+		_, err := e.Simulate(context.Background(), &pb.SimulateRequest{Type: "cpu", Duration: "invalid"})
+		require.Equal(t, grpccodes.InvalidArgument, grpcstatus.Code(err))
+	})
+
+	t.Run("should return an error when a required magnitude parameter is missing", func(t *testing.T) {
+		requests := []*pb.SimulateRequest{
+			{Type: "memory", Duration: "10ms"},
+			{Type: "goroutines", Duration: "10ms"},
+			{Type: "mutex", Duration: "10ms"},
+			{Type: "block", Duration: "10ms"},
+		}
+
+		for _, request := range requests {
+			_, err := e.Simulate(context.Background(), request)
+			require.Equal(t, grpccodes.InvalidArgument, grpcstatus.Code(err))
+		}
+	})
+
+	t.Run("should return an error when the type is unknown", func(t *testing.T) {
+		_, err := e.Simulate(context.Background(), &pb.SimulateRequest{Type: "unknown", Duration: "10ms"})
+		require.Equal(t, grpccodes.InvalidArgument, grpcstatus.Code(err))
+	})
+}
+
+func TestRequest(t *testing.T) {
+	//nolint:noctx
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterEchoserverServer(grpcServer, NewEchoserver())
+	reflection.Register(grpcServer)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	defer grpcServer.Stop()
+
+	e := NewEchoserver()
+
+	t.Run("should invoke the method on the target server", func(t *testing.T) {
+		resp, err := e.Request(context.Background(), &pb.RequestRequest{
+			Uri:     listener.Addr().String(),
+			Method:  "Echoserver.Echo",
+			Message: `{"message":"hi"}`,
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.GetMessage(), "hi")
+	})
+
+	t.Run("should return an error for an unknown method", func(t *testing.T) {
+		_, err := e.Request(context.Background(), &pb.RequestRequest{
+			Uri:     listener.Addr().String(),
+			Method:  "Echoserver.DoesNotExist",
+			Message: `{}`,
+		})
+		require.Error(t, err)
+	})
+}

--- a/pkg/grpcserver/grpcserver_test.go
+++ b/pkg/grpcserver/grpcserver_test.go
@@ -1,0 +1,19 @@
+package grpcserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	t.Run("should start and stop the server", func(t *testing.T) {
+		server := New(Config{Address: "127.0.0.1:0"})
+		require.NotNil(t, server)
+
+		go server.Start()
+		time.Sleep(100 * time.Millisecond)
+		server.Stop()
+	})
+}

--- a/pkg/httpserver/handlers_test.go
+++ b/pkg/httpserver/handlers_test.go
@@ -65,6 +65,17 @@ func TestHealthHandler(t *testing.T) {
 	})
 }
 
+func TestPanicHandler(t *testing.T) {
+	t.Run("should panic", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		require.Panics(t, func() {
+			panicHandler(w, req)
+		})
+	})
+}
+
 func TestStatusHandler(t *testing.T) {
 	t.Run("should return random status code", func(t *testing.T) {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
@@ -110,6 +121,22 @@ func TestTimeouthandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("should flush while waiting for the timeout", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?timeout=200ms&flush=40ms", nil)
+		w := httptest.NewRecorder()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", timeoutHandler)
+		mux.ServeHTTP(w, req)
+
+		body, err := io.ReadAll(w.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Contains(t, string(body), http.StatusText(http.StatusProcessing))
+		require.Contains(t, string(body), http.StatusText(http.StatusOK))
 	})
 
 	t.Run("should return error when timeout parameter is missing", func(t *testing.T) {
@@ -179,6 +206,27 @@ func TestRequest(t *testing.T) {
 		defer server.Close()
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(fmt.Sprintf(`{"method":"GET","url":"%s"}`, server.URL)))
+		w := httptest.NewRecorder()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", requestHandler)
+		mux.ServeHTTP(w, req)
+
+		body, err := io.ReadAll(w.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "test data", string(body))
+	})
+
+	t.Run("should return response when http client options are provided", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "test data")
+		}))
+		defer server.Close()
+
+		requestBody := fmt.Sprintf(`{"method":"GET","url":"%s","httpClientOptions":{"timeout":"5s","transport":{"disableKeepAlives":true,"maxIdleConns":10}}}`, server.URL)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(requestBody))
 		w := httptest.NewRecorder()
 
 		mux := http.NewServeMux()
@@ -347,5 +395,14 @@ func TestWebsocketHandler(t *testing.T) {
 		_, response, err := client.ReadMessage()
 		require.NoError(t, err)
 		require.Equal(t, "test", string(response))
+	})
+
+	t.Run("should fail to upgrade a non-websocket request", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		websocketHandler(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }

--- a/pkg/httpserver/httpclient_test.go
+++ b/pkg/httpserver/httpclient_test.go
@@ -1,0 +1,77 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuration(t *testing.T) {
+	t.Run("should marshal to a duration string", func(t *testing.T) {
+		data, err := json.Marshal(Duration{5 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, `"5s"`, string(data))
+	})
+
+	t.Run("should unmarshal from a duration string", func(t *testing.T) {
+		var d Duration
+		require.NoError(t, json.Unmarshal([]byte(`"5s"`), &d))
+		require.Equal(t, 5*time.Second, d.Duration)
+	})
+
+	t.Run("should unmarshal from a number of nanoseconds", func(t *testing.T) {
+		var d Duration
+		require.NoError(t, json.Unmarshal([]byte(`5000000000`), &d))
+		require.Equal(t, 5*time.Second, d.Duration)
+	})
+
+	t.Run("should return an error for an invalid duration string", func(t *testing.T) {
+		var d Duration
+		require.Error(t, json.Unmarshal([]byte(`"invalid"`), &d))
+	})
+
+	t.Run("should return an error for an unsupported type", func(t *testing.T) {
+		var d Duration
+		require.Error(t, json.Unmarshal([]byte(`true`), &d))
+	})
+
+	t.Run("should return an error for invalid json", func(t *testing.T) {
+		var d Duration
+		require.Error(t, json.Unmarshal([]byte(`{`), &d))
+	})
+}
+
+func TestGetHTTPClient(t *testing.T) {
+	t.Run("should return the default client when options are nil", func(t *testing.T) {
+		require.Equal(t, defaultHTTPClient, getHTTPClient(nil))
+	})
+
+	t.Run("should build a client from the provided options", func(t *testing.T) {
+		enabled := true
+		size := 10
+		maxBytes := int64(1024)
+		duration := &Duration{5 * time.Second}
+
+		options := &HTTPClientOptions{Timeout: duration}
+		options.Transport.TLSHandshakeTimeout = duration
+		options.Transport.DisableKeepAlives = &enabled
+		options.Transport.DisableCompression = &enabled
+		options.Transport.MaxIdleConns = &size
+		options.Transport.MaxIdleConnsPerHost = &size
+		options.Transport.MaxConnsPerHost = &size
+		options.Transport.IdleConnTimeout = duration
+		options.Transport.ResponseHeaderTimeout = duration
+		options.Transport.ExpectContinueTimeout = duration
+		options.Transport.MaxResponseHeaderBytes = &maxBytes
+		options.Transport.WriteBufferSize = &size
+		options.Transport.ReadBufferSize = &size
+		options.Transport.ForceAttemptHTTP2 = &enabled
+
+		client := getHTTPClient(options)
+		require.NotNil(t, client)
+		require.NotEqual(t, defaultHTTPClient, client)
+		require.Equal(t, 5*time.Second, client.Timeout)
+	})
+}

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -1,0 +1,19 @@
+package httpserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	t.Run("should start and stop the server", func(t *testing.T) {
+		server := New(Config{Address: "127.0.0.1:0"})
+		require.NotNil(t, server)
+
+		go server.Start()
+		time.Sleep(100 * time.Millisecond)
+		server.Stop()
+	})
+}


### PR DESCRIPTION
Raise coverage of the previously untested gRPC server (0%) and the
remaining HTTP server paths.

- gRPC: exercise the Echo, Status and Simulate handlers including every
  validation branch, invoke Request against an in-process reflection
  server, and start/stop the server.
- HTTP: cover the timeout flush loop, the websocket upgrade failure, the
  panic handler, request forwarding with custom HTTP client options, the
  Duration JSON (un)marshalling and getHTTPClient, plus server start/stop.