### PR TITLE
fix: resolve bugs and inconsistencies found in project review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # echoserver
 
 The `echoserver` is a HTTP / gRPC server written in Go, which was mainly written
-to dump HTTP requests. Nowdays it can also be used to test / showcase the
+to dump HTTP requests. Nowadays it can also be used to test / showcase the
 instrumentation of a Go application with metrics, logs, traces and profiles. It
 can also be used to test the timeout / header size configuration of a reverse
 proxy.
@@ -31,12 +31,12 @@ helm upgrade --install echoserver oci://ghcr.io/ricoberger/charts/echoserver --v
 
 ## Configuration
 
-```plantext
+```plaintext
 Usage: echoserver [flags]
 
 Flags:
   -h, --help                           Show context-sensitive help.
-      --http-server.address=":8080"    The address where the server should listen on ($HTTP_SERVER_ADDRESS).
+      --http-server.address=":8080"    The address where the HTTP server should listen on ($HTTP_SERVER_ADDRESS).
       --grpc-server.address=":8081"    The address where the gRPC server should listen on ($GRPC_SERVER_ADDRESS).
 ```
 
@@ -96,7 +96,8 @@ export PROMETHEUS_RESOURCE_ATTRIBUTES="service.name,service.namespace"
   or `random`. Return the status code specified in the `status` parameter, e.g.
   `?status=200`.
 - `/timeout`: Wait the given amount of time (`?timeout=1m`) before returning a
-  200 status code.
+  200 status code. The optional `flush` parameter (`?timeout=10s&flush=2s`)
+  writes and flushes a message in the given interval while waiting.
 - `/headersize`: Returns a 200 status code with a header `X-Header-Size` of the
   size defined via `?size=1024`.
 - `/request`: Returns the response of the requested server. The request body
@@ -119,14 +120,17 @@ export PROMETHEUS_RESOURCE_ATTRIBUTES="service.name,service.namespace"
     (`?type=block&duration=10s&workers=100`).
 - `/websocket`: Can be used to test WebSocket connections. It returns the
   message sent over the WebSocket connection.
-- `/metrics`: Returns the captured Prometheus metrics.
+- `/metrics`: Returns the captured Prometheus metrics, when the
+  `OTEL_METRICS_EXPORTER` environment variable is set to `prometheus`.
+- `/debug/pprof/`: Exposes the pprof profiling endpoints (e.g.
+  `/debug/pprof/profile`, `/debug/pprof/heap`, `/debug/pprof/goroutine`).
 
 ### gRPC Endpoints
 
 - `Echoserver.Echo`: Echoes the message sent in the request.
 - `Echoserver.Status`: Returns a gRPC error with the status specified in the
   `status` field of the request or a random gRPC error when the value of the
-  `status` field is `random`.
+  `status` field is empty or `random`.
 - `Echoserver.Request`: Forwards the request to the specified gRPC endpoint and
   returns the response. The request message should have the following structure:
   `{"uri": "localhost:8081", "method": "Echoserver.Echo", "message": "{ \"message\": \"Hello\" }"}`

--- a/cmd/echoserver/Dockerfile
+++ b/cmd/echoserver/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26.4 AS build
 WORKDIR /echoserver
-COPY go.mod  ./
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN export CGO_ENABLED=0 && make build

--- a/pkg/grpcserver/echoserver.go
+++ b/pkg/grpcserver/echoserver.go
@@ -41,9 +41,9 @@ func NewEchoserver() Echoserver {
 }
 
 func (e *echoserver) Echo(ctx context.Context, r *pb.EchoRequest) (*pb.EchoResponse, error) {
-	_, span := tracer.Start(ctx, "Echo")
+	ctx, span := tracer.Start(ctx, "Echo")
 	defer span.End()
-	span.SetAttributes(attribute.Key("message").String(r.GetMessage()))
+	span.SetAttributes(attribute.Key("rpc.parameter.message").String(r.GetMessage()))
 	slog.DebugContext(ctx, "Echo request received.", slog.String("message", r.GetMessage()))
 
 	return &pb.EchoResponse{
@@ -52,9 +52,9 @@ func (e *echoserver) Echo(ctx context.Context, r *pb.EchoRequest) (*pb.EchoRespo
 }
 
 func (e *echoserver) Status(ctx context.Context, r *pb.StatusRequest) (*pb.StatusResponse, error) {
-	_, span := tracer.Start(ctx, "Status")
+	ctx, span := tracer.Start(ctx, "Status")
 	defer span.End()
-	span.SetAttributes(attribute.Key("status").String(r.GetStatus()))
+	span.SetAttributes(attribute.Key("rpc.parameter.status").String(r.GetStatus()))
 	slog.DebugContext(ctx, "Status request received.", slog.String("status", r.GetStatus()))
 
 	randomStatusCodes := []grpccodes.Code{grpccodes.OK, grpccodes.OK, grpccodes.OK, grpccodes.OK, grpccodes.OK, grpccodes.InvalidArgument, grpccodes.NotFound, grpccodes.Internal, grpccodes.Unavailable}
@@ -62,11 +62,7 @@ func (e *echoserver) Status(ctx context.Context, r *pb.StatusRequest) (*pb.Statu
 	if r.GetStatus() == "" || r.GetStatus() == "random" {
 		index, err := rand.Int(rand.Reader, big.NewInt(int64(len(randomStatusCodes))))
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to generate random index.", slog.Any("error", err))
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-
-			return &pb.StatusResponse{}, grpcstatus.Error(grpccodes.Internal, err.Error())
+			return &pb.StatusResponse{}, e.handleError(ctx, span, grpccodes.Internal, "Failed to generate random index.", err)
 		}
 
 		status := randomStatusCodes[index.Int64()]
@@ -98,18 +94,21 @@ func (e *echoserver) Status(ctx context.Context, r *pb.StatusRequest) (*pb.Statu
 		return &pb.StatusResponse{}, grpcstatus.Error(status, status.String())
 	}
 
-	return &pb.StatusResponse{}, grpcstatus.Error(grpccodes.Internal, "Unknown status parameter")
+	return &pb.StatusResponse{}, e.handleError(ctx, span, grpccodes.Internal, "Invalid 'status' parameter.", fmt.Errorf("unknown status %q", r.GetStatus()))
 }
 
 func (e *echoserver) Request(ctx context.Context, r *pb.RequestRequest) (*pb.RequestResponse, error) {
-	_, span := tracer.Start(ctx, "Request")
+	ctx, span := tracer.Start(ctx, "Request")
 	defer span.End()
-	span.SetAttributes(attribute.Key("uri").String(r.GetUri()))
-	span.SetAttributes(attribute.Key("method").String(r.GetMethod()))
-	span.SetAttributes(attribute.Key("message").String(r.GetMessage()))
+	span.SetAttributes(attribute.Key("rpc.parameter.uri").String(r.GetUri()))
+	span.SetAttributes(attribute.Key("rpc.parameter.method").String(r.GetMethod()))
+	span.SetAttributes(attribute.Key("rpc.parameter.message").String(r.GetMessage()))
 	slog.DebugContext(ctx, "Request request received.", slog.String("uri", r.GetUri()), slog.String("method", r.GetMethod()), slog.String("message", r.GetMessage()))
 
-	conn, _ := grpc.NewClient(r.GetUri(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+	conn, err := grpc.NewClient(r.GetUri(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+	if err != nil {
+		return &pb.RequestResponse{}, e.handleError(ctx, span, grpccodes.Internal, "Failed to create grpc client.", err)
+	}
 	defer conn.Close()
 
 	reflectionClient := grpcreflect.NewClientV1(ctx, rpb.NewServerReflectionClient(conn))
@@ -122,8 +121,7 @@ func (e *echoserver) Request(ctx context.Context, r *pb.RequestRequest) (*pb.Req
 		grpcurl.FormatOptions{EmitJSONDefaultFields: true},
 	)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create request parser and formatter.", slog.Any("error", err))
-		return &pb.RequestResponse{}, grpcstatus.Error(grpccodes.Internal, err.Error())
+		return &pb.RequestResponse{}, e.handleError(ctx, span, grpccodes.Internal, "Failed to create request parser and formatter.", err)
 	}
 
 	var output bytes.Buffer
@@ -162,8 +160,7 @@ func (e *echoserver) Request(ctx context.Context, r *pb.RequestRequest) (*pb.Req
 		if errStatus, ok := grpcstatus.FromError(err); ok {
 			h.Status = errStatus
 		} else {
-			slog.ErrorContext(ctx, "Invoke failed.", slog.Any("error", err))
-			return &pb.RequestResponse{}, grpcstatus.Error(grpccodes.Internal, err.Error())
+			return &pb.RequestResponse{}, e.handleError(ctx, span, grpccodes.Internal, "Invoke failed.", err)
 		}
 	}
 
@@ -172,34 +169,34 @@ func (e *echoserver) Request(ctx context.Context, r *pb.RequestRequest) (*pb.Req
 	}, grpcstatus.Error(h.Status.Code(), h.Status.Message())
 }
 
-// simulateInvalidArgument logs the given error, records it on the span and
-// returns a gRPC InvalidArgument error.
-func (e *echoserver) simulateInvalidArgument(ctx context.Context, span trace.Span, message string, err error) error {
+// handleError logs the given error, records it on the span and returns a gRPC
+// error with the given status code.
+func (e *echoserver) handleError(ctx context.Context, span trace.Span, code grpccodes.Code, message string, err error) error {
 	slog.ErrorContext(ctx, message, slog.Any("error", err))
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 
-	return grpcstatus.Error(grpccodes.InvalidArgument, err.Error())
+	return grpcstatus.Error(code, err.Error())
 }
 
 func (e *echoserver) Simulate(ctx context.Context, r *pb.SimulateRequest) (*pb.SimulateResponse, error) {
 	ctx, span := tracer.Start(ctx, "Simulate")
 	defer span.End()
-	span.SetAttributes(attribute.Key("type").String(r.GetType()))
-	span.SetAttributes(attribute.Key("duration").String(r.GetDuration()))
+	span.SetAttributes(attribute.Key("rpc.parameter.type").String(r.GetType()))
+	span.SetAttributes(attribute.Key("rpc.parameter.duration").String(r.GetDuration()))
 	slog.DebugContext(ctx, "Simulate request received.", slog.String("type", r.GetType()), slog.String("duration", r.GetDuration()))
 
 	if r.GetType() == "" {
-		return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Parameter 'type' is missing.", fmt.Errorf("type parameter is missing"))
+		return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'type' parameter.", fmt.Errorf("type parameter is missing"))
 	}
 
 	if r.GetDuration() == "" {
-		return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Parameter 'duration' is missing.", fmt.Errorf("duration parameter is missing"))
+		return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'duration' parameter.", fmt.Errorf("duration parameter is missing"))
 	}
 
 	duration, err := time.ParseDuration(r.GetDuration())
 	if err != nil {
-		return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Failed to parse 'duration' parameter.", err)
+		return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'duration' parameter.", fmt.Errorf("failed to parse 'duration' parameter: %w", err))
 	}
 
 	var message string
@@ -209,34 +206,34 @@ func (e *echoserver) Simulate(ctx context.Context, r *pb.SimulateRequest) (*pb.S
 		message = fmt.Sprintf("simulated %q for %s", r.GetType(), duration)
 	case "memory":
 		if r.GetSize() <= 0 {
-			return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Invalid 'size' parameter.", fmt.Errorf("size parameter is missing"))
+			return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'size' parameter.", fmt.Errorf("size parameter must be greater than zero"))
 		}
-		span.SetAttributes(attribute.Key("size").Int64(r.GetSize()))
+		span.SetAttributes(attribute.Key("rpc.parameter.size").Int64(r.GetSize()))
 		simulate.Memory(ctx, duration, int(r.GetSize()))
 		message = fmt.Sprintf("simulated %q for %s (%d bytes)", r.GetType(), duration, r.GetSize())
 	case "goroutines":
 		if r.GetCount() <= 0 {
-			return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Invalid 'count' parameter.", fmt.Errorf("count parameter is missing"))
+			return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'count' parameter.", fmt.Errorf("count parameter must be greater than zero"))
 		}
-		span.SetAttributes(attribute.Key("count").Int64(r.GetCount()))
+		span.SetAttributes(attribute.Key("rpc.parameter.count").Int64(r.GetCount()))
 		simulate.Goroutines(ctx, duration, int(r.GetCount()))
 		message = fmt.Sprintf("simulated %q for %s (%d goroutines)", r.GetType(), duration, r.GetCount())
 	case "mutex":
 		if r.GetWorkers() <= 0 {
-			return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Invalid 'workers' parameter.", fmt.Errorf("workers parameter is missing"))
+			return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'workers' parameter.", fmt.Errorf("workers parameter must be greater than zero"))
 		}
-		span.SetAttributes(attribute.Key("workers").Int64(r.GetWorkers()))
+		span.SetAttributes(attribute.Key("rpc.parameter.workers").Int64(r.GetWorkers()))
 		simulate.Mutex(ctx, duration, int(r.GetWorkers()))
 		message = fmt.Sprintf("simulated %q for %s (%d workers)", r.GetType(), duration, r.GetWorkers())
 	case "block":
 		if r.GetWorkers() <= 0 {
-			return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Invalid 'workers' parameter.", fmt.Errorf("workers parameter is missing"))
+			return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Invalid 'workers' parameter.", fmt.Errorf("workers parameter must be greater than zero"))
 		}
-		span.SetAttributes(attribute.Key("workers").Int64(r.GetWorkers()))
+		span.SetAttributes(attribute.Key("rpc.parameter.workers").Int64(r.GetWorkers()))
 		simulate.Block(ctx, duration, int(r.GetWorkers()))
 		message = fmt.Sprintf("simulated %q for %s (%d workers)", r.GetType(), duration, r.GetWorkers())
 	default:
-		return &pb.SimulateResponse{}, e.simulateInvalidArgument(ctx, span, "Unknown simulation type.", fmt.Errorf("unknown simulation type %q", r.GetType()))
+		return &pb.SimulateResponse{}, e.handleError(ctx, span, grpccodes.InvalidArgument, "Unknown simulation type.", fmt.Errorf("unknown simulation type %q", r.GetType()))
 	}
 
 	return &pb.SimulateResponse{

--- a/pkg/grpcserver/echoserver_test.go
+++ b/pkg/grpcserver/echoserver_test.go
@@ -138,4 +138,15 @@ func TestRequest(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("should return an error for an invalid uri", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := e.Request(context.Background(), &pb.RequestRequest{
+				Uri:     "unknown-scheme://invalid",
+				Method:  "Echoserver.Echo",
+				Message: `{}`,
+			})
+			require.Error(t, err)
+		})
+	})
 }

--- a/pkg/grpcserver/grpcserver.go
+++ b/pkg/grpcserver/grpcserver.go
@@ -42,6 +42,7 @@ func (s *server) Start() {
 	listener, err := listenConfig.Listen(context.Background(), "tcp", s.address)
 	if err != nil {
 		slog.Error("Failed to create listener.", slog.Any("error", err))
+		return
 	}
 	slog.Info("Start server...", slog.String("address", listener.Addr().String()))
 

--- a/pkg/grpcserver/grpcserver_test.go
+++ b/pkg/grpcserver/grpcserver_test.go
@@ -16,4 +16,13 @@ func TestServer(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		server.Stop()
 	})
+
+	t.Run("should return without panic when the listener can not be created", func(t *testing.T) {
+		server := New(Config{Address: "invalid-address"})
+		require.NotNil(t, server)
+
+		require.NotPanics(t, func() {
+			server.Start()
+		})
+	})
 }

--- a/pkg/grpcserver/middleware/requestid/requestid.go
+++ b/pkg/grpcserver/middleware/requestid/requestid.go
@@ -2,12 +2,8 @@ package requestid
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"fmt"
-	"os"
-	"strings"
-	"sync/atomic"
+
+	id "github.com/ricoberger/echoserver/pkg/requestid"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -17,26 +13,7 @@ type ctxKeyRequestID int
 
 const RequestIDKey ctxKeyRequestID = 0
 
-var RequestIDHeader = "x-request-id"
-
-var prefix string
-var reqid uint64
-
-func init() {
-	hostname, err := os.Hostname()
-	if hostname == "" || err != nil {
-		hostname = "localhost"
-	}
-	var buf [12]byte
-	var b64 string
-	for len(b64) < 10 {
-		rand.Read(buf[:])
-		b64 = base64.StdEncoding.EncodeToString(buf[:])
-		b64 = strings.NewReplacer("+", "", "/", "").Replace(b64)
-	}
-
-	prefix = fmt.Sprintf("%s/%s", hostname, b64[0:10])
-}
+const RequestIDHeader = id.Header
 
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
@@ -47,8 +24,7 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			}
 		}
 		if requestID == "" {
-			myid := atomic.AddUint64(&reqid, 1)
-			requestID = fmt.Sprintf("%s-%06d", prefix, myid)
+			requestID = id.Generate()
 		}
 		ctx = context.WithValue(ctx, RequestIDKey, requestID)
 		return handler(ctx, req)
@@ -65,8 +41,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 			}
 		}
 		if requestID == "" {
-			myid := atomic.AddUint64(&reqid, 1)
-			requestID = fmt.Sprintf("%s-%06d", prefix, myid)
+			requestID = id.Generate()
 		}
 		ctx = context.WithValue(ctx, RequestIDKey, requestID)
 		wrapped := &wrappedServerStream{

--- a/pkg/httpserver/handlers.go
+++ b/pkg/httpserver/handlers.go
@@ -34,6 +34,8 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+	// Echoing the request back is the purpose of this endpoint, so the
+	// reflected content is intended.
 	//nolint:gosec
 	w.Write(dump)
 }
@@ -82,6 +84,11 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if status < 100 || status > 999 {
+		handleError(ctx, w, span, http.StatusBadRequest, "Invalid 'status' parameter.", fmt.Errorf("status parameter must be a valid http status code (100-999)"))
+		return
+	}
+
 	w.WriteHeader(status)
 	w.Write([]byte(http.StatusText(status)))
 }
@@ -99,41 +106,56 @@ func timeoutHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// stopFlush stops the flush goroutine and waits until it has returned, so
+	// it can not write to the response concurrently with the final writes
+	// below.
+	stopFlush := func() {}
+
 	if flushString := r.URL.Query().Get("flush"); flushString != "" {
-		if flush, err := time.ParseDuration(flushString); err == nil && flush > 0 {
-			done := make(chan bool)
+		flush, err := time.ParseDuration(flushString)
+		if err != nil || flush <= 0 {
+			if err == nil {
+				err = fmt.Errorf("flush parameter must be a positive duration")
+			}
+			handleError(ctx, w, span, http.StatusBadRequest, "Invalid 'flush' parameter.", err)
+			return
+		}
 
-			go func() {
-				ticker := time.NewTicker(flush)
-				defer ticker.Stop()
+		done := make(chan bool)
 
-				for {
-					select {
-					case <-done:
-						return
-					case <-ticker.C:
-						if f, ok := w.(http.Flusher); ok {
-							span.AddEvent("Flush")
-							w.Write([]byte(http.StatusText(http.StatusProcessing) + "\n"))
-							f.Flush()
-						}
+		go func() {
+			ticker := time.NewTicker(flush)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					if f, ok := w.(http.Flusher); ok {
+						span.AddEvent("Flush")
+						w.Write([]byte(http.StatusText(http.StatusProcessing) + "\n"))
+						f.Flush()
 					}
 				}
-			}()
+			}
+		}()
 
-			defer func() {
-				done <- true
-			}()
+		stopFlush = func() {
+			done <- true
 		}
 	}
 
 	select {
 	case <-ctx.Done():
-		w.Write([]byte(http.StatusText(http.StatusBadRequest)))
+		// The client canceled the request or the server is shutting down, so
+		// there is no point in writing a response.
+		stopFlush()
 		return
 	case <-time.After(timeout):
 	}
 
+	stopFlush()
 	w.Write([]byte(http.StatusText(http.StatusOK)))
 }
 
@@ -194,7 +216,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := getHTTPClient(request.HTTPClientOptions).Do(req)
 	if err != nil {
-		handleError(ctx, w, span, http.StatusBadRequest, "Failed to do http request.", err)
+		handleError(ctx, w, span, http.StatusBadGateway, "Failed to do http request.", err)
 		return
 	}
 
@@ -202,7 +224,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		handleError(ctx, w, span, http.StatusBadRequest, "Failed to read response body.", err)
+		handleError(ctx, w, span, http.StatusBadGateway, "Failed to read response body.", err)
 		return
 	}
 

--- a/pkg/httpserver/handlers_test.go
+++ b/pkg/httpserver/handlers_test.go
@@ -109,6 +109,17 @@ func TestStatusHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
+
+	t.Run("should return error for out of range status code", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?status=99", nil)
+		w := httptest.NewRecorder()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", statusHandler)
+		mux.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestTimeouthandler(t *testing.T) {
@@ -152,6 +163,17 @@ func TestTimeouthandler(t *testing.T) {
 
 	t.Run("should return error when timeout parameter is invalid", func(t *testing.T) {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?timeout=invalid", nil)
+		w := httptest.NewRecorder()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", timeoutHandler)
+		mux.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("should return error when flush parameter is invalid", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/?timeout=1s&flush=invalid", nil)
 		w := httptest.NewRecorder()
 
 		mux := http.NewServeMux()
@@ -249,6 +271,17 @@ func TestRequest(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("should return bad gateway when request target is unreachable", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(`{"method":"GET","url":"http://127.0.0.1:1"}`))
+		w := httptest.NewRecorder()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", requestHandler)
+		mux.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadGateway, w.Code)
 	})
 }
 

--- a/pkg/httpserver/middleware/requestid/requestid.go
+++ b/pkg/httpserver/middleware/requestid/requestid.go
@@ -2,47 +2,23 @@ package requestid
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"fmt"
 	"net/http"
-	"os"
-	"strings"
-	"sync/atomic"
+
+	id "github.com/ricoberger/echoserver/pkg/requestid"
 )
 
 type ctxKeyRequestID int
 
 const RequestIDKey ctxKeyRequestID = 0
 
-var RequestIDHeader = "x-request-id"
-
-var prefix string
-var reqid uint64
-
-func init() {
-	hostname, err := os.Hostname()
-	if hostname == "" || err != nil {
-		hostname = "localhost"
-	}
-	var buf [12]byte
-	var b64 string
-	for len(b64) < 10 {
-		rand.Read(buf[:])
-		b64 = base64.StdEncoding.EncodeToString(buf[:])
-		b64 = strings.NewReplacer("+", "", "/", "").Replace(b64)
-	}
-
-	prefix = fmt.Sprintf("%s/%s", hostname, b64[0:10])
-}
+const RequestIDHeader = id.Header
 
 func Handler(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		requestID := r.Header.Get(RequestIDHeader)
 		if requestID == "" {
-			myid := atomic.AddUint64(&reqid, 1)
-			requestID = fmt.Sprintf("%s-%06d", prefix, myid)
+			requestID = id.Generate()
 		}
 		ctx = context.WithValue(ctx, RequestIDKey, requestID)
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/instrument/client.go
+++ b/pkg/instrument/client.go
@@ -52,6 +52,11 @@ func (c *client) Shutdown() {
 		slog.ErrorContext(ctx, "Graceful shutdown of the logger provider failed.", slog.Any("error", err))
 	}
 
+	err = c.meterProvider.Shutdown(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Graceful shutdown of the meter provider failed.", slog.Any("error", err))
+	}
+
 	err = c.tracerProvider.Shutdown(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "Graceful shutdown of the tracer provider failed.", slog.Any("error", err))
@@ -72,7 +77,7 @@ func New(ctx context.Context) (Client, error) {
 		b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader|b3.B3SingleHeader)),
 	))
 
-	defaultResource, err := newReource(ctx)
+	defaultResource, err := newResource(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +113,7 @@ func New(ctx context.Context) (Client, error) {
 	}, nil
 }
 
-func newReource(ctx context.Context) (*resource.Resource, error) {
+func newResource(ctx context.Context) (*resource.Resource, error) {
 	options := []resource.Option{
 		resource.WithAttributes(attribute.Key("service.name").String("echoserver")),
 		resource.WithAttributes(attribute.Key("service.version").String(version.Version)),
@@ -210,6 +215,9 @@ func newMeterProvider(ctx context.Context, defaultResource *resource.Resource) (
 	case "prometheus":
 		var resourceAttributes []attribute.Key
 		for value := range strings.SplitSeq(os.Getenv("PROMETHEUS_RESOURCE_ATTRIBUTES"), ",") {
+			if value == "" {
+				continue
+			}
 			resourceAttributes = append(resourceAttributes, attribute.Key(value))
 		}
 

--- a/pkg/instrument/logger.go
+++ b/pkg/instrument/logger.go
@@ -76,3 +76,11 @@ func (h *CustomHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	return h.Handler.Handle(ctx, r)
 }
+
+func (h *CustomHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &CustomHandler{h.Handler.WithAttrs(attrs), h.Resource}
+}
+
+func (h *CustomHandler) WithGroup(name string) slog.Handler {
+	return &CustomHandler{h.Handler.WithGroup(name), h.Resource}
+}

--- a/pkg/requestid/requestid.go
+++ b/pkg/requestid/requestid.go
@@ -1,0 +1,41 @@
+// Package requestid provides the shared request id header name and generator
+// used by the HTTP and gRPC request id middlewares.
+package requestid
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// Header is the name of the header / metadata key which contains the request
+// id.
+const Header = "x-request-id"
+
+var prefix string
+var reqid uint64
+
+func init() {
+	hostname, err := os.Hostname()
+	if hostname == "" || err != nil {
+		hostname = "localhost"
+	}
+	var buf [12]byte
+	var b64 string
+	for len(b64) < 10 {
+		rand.Read(buf[:])
+		b64 = base64.StdEncoding.EncodeToString(buf[:])
+		b64 = strings.NewReplacer("+", "", "/", "").Replace(b64)
+	}
+
+	prefix = fmt.Sprintf("%s/%s", hostname, b64[0:10])
+}
+
+// Generate returns a new unique request id.
+func Generate() string {
+	myid := atomic.AddUint64(&reqid, 1)
+	return fmt.Sprintf("%s-%06d", prefix, myid)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,11 +1,8 @@
 package version
 
 import (
-	"bytes"
 	"log/slog"
 	"runtime"
-	"strings"
-	"text/template"
 )
 
 // Build information. Populated at build-time.
@@ -17,34 +14,6 @@ var (
 	BuildDate string
 	GoVersion = runtime.Version()
 )
-
-// versionInfoTmpl contains the template used by Print.
-var versionInfoTmpl = `
-{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
-  build user:       {{.buildUser}}
-  build date:       {{.buildDate}}
-  go version:       {{.goVersion}}
-`
-
-// Print returns version information.
-func Print(program string) (string, error) {
-	data := map[string]string{
-		"program":   program,
-		"version":   Version,
-		"revision":  Revision,
-		"branch":    Branch,
-		"buildUser": BuildUser,
-		"buildDate": BuildDate,
-		"goVersion": GoVersion,
-	}
-
-	var buf bytes.Buffer
-
-	tmpl := template.Must(template.New("version").Parse(versionInfoTmpl))
-	tmpl.ExecuteTemplate(&buf, "version", data)
-
-	return strings.TrimSpace(buf.String()), nil
-}
 
 // Info returns version, branch and revision information.
 func Info() {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,26 +1,10 @@
 package version
 
 import (
-	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestPrint(t *testing.T) {
-	goVersion := runtime.Version()
-
-	Version = "v0.7.0-29-gcc373f2"
-	Revision = "cc373f263575773f1349bbd354e803cc85f9edcd"
-	Branch = "main"
-	BuildUser = "root"
-	BuildDate = "2021-12-23@09:46:17"
-
-	version, err := Print("echoserver")
-	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("echoserver, version v0.7.0-29-gcc373f2 (branch: main, revision: cc373f263575773f1349bbd354e803cc85f9edcd)\n  build user:       root\n  build date:       2021-12-23@09:46:17\n  go version:       %s", goVersion), version)
-}
 
 func TestInfo(t *testing.T) {
 	Version = "v0.7.0-29-gcc373f2"


### PR DESCRIPTION
Fixes findings from a deep project review:

- gRPC Request: handle grpc.NewClient error instead of deferring Close on a possibly nil connection
- gRPC Start: return after listener creation fails instead of panicking on listener.Addr()
- HTTP /status: validate status code range (100-999) to avoid a WriteHeader panic
- HTTP /timeout: stop the flush goroutine before the final writes to fix a data race and return 400 for an invalid flush parameter
- HTTP /request: return 502 instead of 400 when the upstream request fails
- gRPC handlers: add a shared handleError helper (mirrors the HTTP server), rebind ctx from tracer.Start, prefix span attributes with rpc.parameter.* and align error messages with the HTTP server
- instrument: shut down the meter provider, add WithAttrs/WithGroup to CustomHandler so enrichment survives logger.With, skip empty Prometheus resource attribute keys, rename newReource to newResource
- requestid: deduplicate request id generation from the HTTP and gRPC middlewares into a shared pkg/requestid package
- version: remove the dead Print function
- Dockerfile: copy go.sum next to go.mod
- README: fix typos, document the flush parameter, the /debug/pprof endpoints and when /metrics is available

Includes regression tests for the fixed bugs.