### PR TITLE
ci(helm): publish chart if version does not exists

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -68,10 +68,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Version
-        id: version
+      - name: Lint Helm Chart
         run: |
-          echo VERSION=$(yq -r .version ./charts/echoserver/Chart.yaml) >> $GITHUB_ENV
+          helm lint ./charts/echoserver
+
+      - name: Template Helm Chart
+        run: |
+          helm template ./charts/echoserver
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -79,7 +83,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
-      - name: Package and Push Helm Chart
+      - name: Set Version
+        id: version
         run: |
-          helm package ./charts/echoserver --version ${{ env.VERSION }}
-          helm push ./echoserver-${{ env.VERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          echo version=$(yq -r .version ./charts/echoserver/Chart.yaml) >> $GITHUB_OUTPUT
+
+      - name: Check if Version is Already Published
+        id: check
+        run: |
+          if helm show chart oci://ghcr.io/${{ github.repository_owner }}/charts/echoserver --version ${{ steps.version.outputs.version }} > /dev/null 2>&1; then
+            echo "Chart version ${{ steps.version.outputs.version }} is already published, skipping"
+            echo "publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Chart version ${{ steps.version.outputs.version }} is not published yet"
+            echo "publish=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Package and Push Helm Chart
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          helm package ./charts/echoserver --version ${{ steps.version.outputs.version }}
+          helm push ./echoserver-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -60,3 +60,20 @@ jobs:
           context: .
           file: ./cmd/echoserver/Dockerfile
           platforms: linux/amd64
+
+  helm:
+    name: Helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Lint Helm Chart
+        run: |
+          helm lint ./charts/echoserver
+
+      - name: Template Helm Chart
+        run: |
+          helm template ./charts/echoserver


### PR DESCRIPTION
Improve the continuous delivery workflow to publish the Helm chart only
if the version does not already exists in the Helm repository. This
prevents overwriting existing chart versions and ensures that only new
versions are published.

Also add a linting and templating step to the workflow to validate the
Helm chart before publishing.
